### PR TITLE
Resume default audio engine on start.

### DIFF
--- a/library/src/cpp/native/oboeaudio.cpp
+++ b/library/src/cpp/native/oboeaudio.cpp
@@ -13,7 +13,9 @@
 
 OBOEAUDIO_METHOD(void, init)(JNIEnv *env, jobject self) {
     // set default audioEngine in OboeAudio class
-    set_var_as(env, self, "audioEngine", new audio_engine(audio_engine::mode::async, 2));
+    auto *default_engine = new audio_engine(audio_engine::mode::async, 2);
+    default_engine->resume();
+    set_var_as(env, self, "audioEngine", default_engine);
 }
 
 inline jlong createMusic(JNIEnv *env, jobject self, std::unique_ptr<audio_decoder> &&decoder) {


### PR DESCRIPTION
This brings over the one recent commit to libgdx-oboe, from May 2022.